### PR TITLE
Update getAnnotation.R

### DIFF
--- a/R/getAnnotation.R
+++ b/R/getAnnotation.R
@@ -72,8 +72,6 @@ getAnnotation = function(myBgeeObject){
       myData <- file.path(myBgeeObject$pathToData, myData)
       # move annotation files from "experiments repository" to pathToData repository in order to be consistent with zip uncompression
       file.rename(from = myData,  to = file.path(myBgeeObject$pathToData, basename(myData)))
-      # delete the "experiment repository" folder
-      unlink(dirname(myData), recursive = TRUE)
     }else{
       stop("\nThe annotation file can not be uncompressed because it is not a zip nor a tar.gz file\n")
     }


### PR DESCRIPTION
I was getting errors that the FTP download was not completing. The same as this issue from 2 years ago: https://github.com/BgeeDB/BgeeDB_R/issues/27. I found this was because of how the Bgee database and R package is set up now, the path that is set to where files are downloaded and extracted (pathToData), is the same path that line 76 of getAnnotation.R script deletes by unlinking (dirname(myData)). This removes all downloaded BGee data when running and therefore returns an error. I guess this line was left over from a previous set up. I think just removing will be a fix with no problems.